### PR TITLE
Add rescue to warn of exceptions when receiving invalid/mangled sflow packets

### DIFF
--- a/lib/logstash/codecs/sflow.rb
+++ b/lib/logstash/codecs/sflow.rb
@@ -182,6 +182,6 @@ class LogStash::Codecs::Sflow < LogStash::Codecs::Base
     end
   rescue BinData::ValidityError, EOFError, IOError, RangeError => e
     @logger.warn("Invalid sflow packet received (#{e})")
-    Sflow.instance_variables.each { |ivar| puts "#{ivar}: #{Sflow.instance_variable_get(ivar)}" }
+#    Sflow.instance_variables.each { |ivar| puts "#{ivar}: #{Sflow.instance_variable_get(ivar)}" }
   end # def decode
 end # class LogStash::Filters::Sflow

--- a/lib/logstash/codecs/sflow.rb
+++ b/lib/logstash/codecs/sflow.rb
@@ -180,5 +180,7 @@ class LogStash::Codecs::Sflow < LogStash::Codecs::Base
     events.each do |event|
       yield event
     end
+    rescue BinData::ValidityError, IOError => e
+      @logger.warn("Invalid netflow packet received (#{e})")
   end # def decode
 end # class LogStash::Filters::Sflow

--- a/lib/logstash/codecs/sflow.rb
+++ b/lib/logstash/codecs/sflow.rb
@@ -180,7 +180,8 @@ class LogStash::Codecs::Sflow < LogStash::Codecs::Base
     events.each do |event|
       yield event
     end
-    rescue BinData::ValidityError, IOError => e
-      @logger.warn("Invalid sflow packet received (#{e})")
+  rescue BinData::ValidityError, IOError, RangeError => e
+    @logger.warn("Invalid sflow packet received (#{e})")
+    Sflow.instance_variables.each { |ivar| puts "#{ivar}: #{Sflow.instance_variable_get(ivar)}" }
   end # def decode
 end # class LogStash::Filters::Sflow

--- a/lib/logstash/codecs/sflow.rb
+++ b/lib/logstash/codecs/sflow.rb
@@ -181,6 +181,6 @@ class LogStash::Codecs::Sflow < LogStash::Codecs::Base
       yield event
     end
     rescue BinData::ValidityError, IOError => e
-      @logger.warn("Invalid netflow packet received (#{e})")
+      @logger.warn("Invalid sflow packet received (#{e})")
   end # def decode
 end # class LogStash::Filters::Sflow

--- a/lib/logstash/codecs/sflow.rb
+++ b/lib/logstash/codecs/sflow.rb
@@ -180,7 +180,7 @@ class LogStash::Codecs::Sflow < LogStash::Codecs::Base
     events.each do |event|
       yield event
     end
-  rescue BinData::ValidityError, IOError, RangeError => e
+  rescue BinData::ValidityError, EOFError, IOError, RangeError => e
     @logger.warn("Invalid sflow packet received (#{e})")
     Sflow.instance_variables.each { |ivar| puts "#{ivar}: #{Sflow.instance_variable_get(ivar)}" }
   end # def decode

--- a/logstash-codec-sflow.gemspec
+++ b/logstash-codec-sflow.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name = 'logstash-codec-sflow'
-  s.version = '2.0.0'
+  s.version = '2.0.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'The sflow codec is for decoding SFlow v5 flows.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'
@@ -21,9 +21,10 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
+  s.add_runtime_dependency 'logstash-core', '>= 5.4.0', '<= 5.4.1'
   s.add_runtime_dependency 'bindata', ['~> 2.3']
   s.add_runtime_dependency 'lru_redux', ['~> 1.1']
   s.add_runtime_dependency 'snmp', ['~> 1.2']
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '<= 1.3.1'
 end
 


### PR DESCRIPTION
This is to fix an issue where Logstash drops the UDP listener when receiving an invalid/mangled sflow packet and closes with the following exception: 

Exception in inputworker {"exception"=>#<EOFError: End of file reached>, "backtrace"=>["/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/io.rb:314:in `read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/io.rb:333:in `accumulate_big_endian_bits'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/io.rb:322:in `read_big_endian_bits'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/io.rb:295:in `readbits'", "(eval):30:in `read_and_return_value'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/base_primitive.rb:129:in `do_read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/struct.rb:139:in `do_read'", "org/jruby/RubyArray.java:1613:in `each'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/struct.rb:139:in `do_read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/array.rb:322:in `do_read'", "org/jruby/RubyArray.java:1613:in `each'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/array.rb:322:in `do_read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/struct.rb:139:in `do_read'", "org/jruby/RubyArray.java:1613:in `each'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/struct.rb:139:in `do_read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/base.rb:147:in `read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/base.rb:254:in `start_read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/base.rb:145:in `read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/bindata-2.4.0/lib/bindata/base.rb:21:in `read'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-codec-sflow-2.0.0/lib/logstash/codecs/sflow.rb:105:in `decode'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-udp-3.1.0/lib/logstash/inputs/udp.rb:118:in `inputworker'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-udp-3.1.0/lib/logstash/inputs/udp.rb:89:in `udp_listener'"]}