### PR TITLE
fixed deps to work with later versions of LS

### DIFF
--- a/logstash-codec-sflow.gemspec
+++ b/logstash-codec-sflow.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name = 'logstash-codec-sflow'
-  s.version = '2.0.1'
+  s.version = '2.0.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'The sflow codec is for decoding SFlow v5 flows.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'
@@ -21,10 +21,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
-  s.add_runtime_dependency 'logstash-core', '>= 5.4.0', '<= 5.4.1'
+  s.add_runtime_dependency 'logstash-core', '>= 5.4.0', '<= 6.9.9'
   s.add_runtime_dependency 'bindata', ['~> 2.3']
   s.add_runtime_dependency 'lru_redux', ['~> 1.1']
   s.add_runtime_dependency 'snmp', ['~> 1.2']
   s.add_development_dependency 'logstash-devutils', '<= 1.3.1'
 end
-


### PR DESCRIPTION
The range of versions for the `logstash-core` dependency prevented v2.0.1 (downloaded from rubygems.org) from loading in more recent version of Logstash.

This PR fixes this issue by allowing a wide range of `logstash-core` versions. This is a badly needed fix as many users are seeing issues do to lack of handling of misformed sflow packets, which was added to 2.0.1. 