### PR TITLE
IPv6 Flow Sample Support

### DIFF
--- a/lib/logstash/codecs/sflow/packet_header.rb
+++ b/lib/logstash/codecs/sflow/packet_header.rb
@@ -89,6 +89,27 @@ class IPV4Header < BinData::Record
   end
 end
 
+# noinspection RubyResolve,RubyResolve
+class IPV6Header < BinData::Record
+  mandatory_parameter :size_header
+
+  endian :big
+  bit4 :ip_version
+  bit6 :ip_dscp
+  bit2 :ip_ecn
+  bit20 :ipv6_flow_label
+  uint16 :ip_total_length
+  uint8 :ip_protocol
+  uint8 :ipv6_hop_limit
+  sflow_ip6_addr :src_ip
+  sflow_ip6_addr :dst_ip
+  choice :ip_data, :selection => :ip_protocol do
+    tcp_header 6, :size_header => lambda { size_header - 320 }
+    udp_header 17, :size_header => lambda { size_header - 320 }
+    unknown_header :default, :size_header => lambda { size_header - 320 }
+  end
+end
+
 # noinspection RubyResolve
 class IPHeader < BinData::Record
   mandatory_parameter :size_header
@@ -126,6 +147,7 @@ class EthernetHeader < BinData::Record
   uint16 :eth_type
   choice :eth_data, :selection => :eth_type do
     ip_header 2048, :size_header => lambda { size_header - (14 * 8) }
+    ipv6_header 34525, :size_header => lambda { size_header - (14 * 8) }
     vlan_header 33024, :size_header => lambda { size_header - (14 * 8) }
     unknown_header :default, :size_header => lambda { size_header - (14 * 8) }
   end


### PR DESCRIPTION
Added decoding of IPv6 Headers so that IPv6 flow samples are fully decoded. An example of the output is (NOTE: some of the normally removed fields are also present for testing):

```
{
                             "drops" => "0",
                        "tcp_is_fin" => "0",
                   "tcp_window_size" => "269",
                    "ipv6_hop_limit" => "64",
                 "tcp_header_length" => "8",
                          "@version" => "1",
                       "sample_pool" => "1756757760",
                   "input_interface" => "516",
                    "source_id_type" => "0",
                          "src_vlan" => "12",
                            "dst_ip" => "fe80::8ee:6dab:960c:2072",
                            "padded" => "0",
                            "ip_ecn" => "0",
                        "tcp_is_syn" => "0",
                          "protocol" => "1",
                          "dst_port" => "56324",
                        "sflow_type" => "flow_sample",
                   "ipv6_flow_label" => "0",
                        "ip_version" => "6",
                  "output_interface" => "508",
                    "tcp_ack_number" => "1205998910",
                           "ip_dscp" => "4",
  "frame_length_times_sampling_rate" => 172228608,
                       "header_size" => "128",
                              "type" => "sflow",
                      "frame_length" => "1314",
                          "agent_ip" => "192.168.1.2",
                      "tcp_is_reset" => "0",
                        "@timestamp" => 2018-07-01T12:21:38.527Z,
              "flow_sequence_number" => "14",
                      "tcp_is_nonce" => "0",
                          "src_port" => "22",
                   "ip_total_length" => "1256",
                        "tcp_is_cwr" => "0",
                        "tcp_is_ack" => "1",
                   "source_id_index" => "516",
                     "tcp_is_urgent" => "0",
                              "host" => "192.168.1.2",
                       "ip_protocol" => "6",
                          "eth_type" => "34525",
                            "src_ip" => "fe80::c54c:3bc5:fe73:8afe",
                      "sub_agent_id" => "16",
                "tcp_urgent_pointer" => "0",
                          "dst_vlan" => "12",
                      "uptime_in_ms" => "1443891469",
                     "sampling_rate" => "131072",
                       "tcp_is_push" => "1",
                    "tcp_seq_number" => "320657664",
                      "src_priority" => "0",
                      "dst_priority" => "0",
                           "eth_src" => "f0:de:f1:c3:6d:bd",
                   "tcp_is_ecn_echo" => "0",
                      "tcp_checksum" => "36328",
                           "eth_dst" => "f0:de:f1:e3:f7:73",
                      "tcp_reserved" => "0",
                   "sequence_number" => "36309",
                          "stripped" => "4"
}
```