### PR TITLE
Replace deprecated event accessor

### DIFF
--- a/lib/logstash/codecs/sflow.rb
+++ b/lib/logstash/codecs/sflow.rb
@@ -61,7 +61,7 @@ class LogStash::Codecs::Sflow < LogStash::Codecs::Base
 
   def snmp_call(event)
     if @snmp_interface
-      if event.include?('source_id_type') and event['source_id_type'].to_s == '0'
+      if event.include?('source_id_type') and event.get('source_id_type').to_s == '0'
         if event.include?('source_id_index')
           event.set('source_id_index_descr', @snmp.get_interface(event.get('agent_ip'), event.get('source_id_index')))
         end


### PR DESCRIPTION
Change the `event[field]` notation to use `event.get`. This allows the plugin to be used in more recent versions of Logstash.