### PR TITLE
Fixes for parsing RawPacketHeader

### DIFF
--- a/lib/logstash/codecs/sflow/flow_record.rb
+++ b/lib/logstash/codecs/sflow/flow_record.rb
@@ -5,8 +5,9 @@ require 'logstash/codecs/sflow/util'
 require 'logstash/codecs/sflow/packet_header'
 
 # noinspection RubyResolve
-class RawPacketHeader < BinData::Record
+class RawPacketHeader < BinData::Buffer
   mandatory_parameter :record_length
+  default_parameters :length => :record_length
 
   endian :big
   uint32 :protocol
@@ -18,7 +19,6 @@ class RawPacketHeader < BinData::Record
     ip_header 11, :size_header => lambda { header_size * 8 }
     skip :default, :length => :header_size
   end
-  bit :padded, :nbits => lambda { (record_length - (header_size + 16)) * 8 } #padded data
 end
 
 # noinspection RubyResolve

--- a/lib/logstash/codecs/sflow/packet_header.rb
+++ b/lib/logstash/codecs/sflow/packet_header.rb
@@ -78,10 +78,22 @@ class IPV4Header < BinData::Record
   array :ip_options, :initial_length => lambda { (((ip_header_length * 4) - 20)/4).ceil }, :onlyif => :is_options? do
     string :ip_option, :length => 4, :pad_byte => "\0"
   end
-  choice :ip_data, :selection => :ip_protocol do
+  choice :ip_data, :selection => :ip_protocol, :onlyif => lambda { has_data?(size_header) } do
     tcp_header 6, :size_header => lambda { size_header - (ip_header_length * 4 * 8) }
     udp_header 17, :size_header => lambda { size_header - (ip_header_length * 4 * 8) }
     unknown_header :default, :size_header => lambda { size_header - (ip_header_length * 4 * 8) }
+  end
+
+  def has_data?(size_header)
+    bytes_left = size_header / 8 - ip_header_length * 4
+    case ip_protocol
+    when 6
+      return bytes_left >= 20
+    when 17
+      return bytes_left >= 8
+    else
+      return true
+    end
   end
 
   def is_options?

--- a/lib/logstash/codecs/sflow/packet_header.rb
+++ b/lib/logstash/codecs/sflow/packet_header.rb
@@ -36,13 +36,13 @@ class TcpHeader < BinData::Record
   uint16 :tcp_window_size
   uint16 :tcp_checksum
   uint16 :tcp_urgent_pointer
-  array :tcp_options, :initial_length => lambda { (((tcp_header_length * 4) - 20)/4).ceil }, :onlyif => :is_options? do
+  array :tcp_options, :initial_length => lambda { tcp_header_length - 5 }, :onlyif => lambda { is_options?(size_header) } do
     string :tcp_option, :length => 4, :pad_byte => "\0"
   end
   bit :data, :nbits => lambda { size_header - data.rel_offset * 8 }
 
-  def is_options?
-    tcp_header_length.to_i > 5
+  def is_options?(size_header)
+    tcp_header_length.to_i > 5 and size_header >= tcp_header_length * 4 * 8
   end
 end
 

--- a/lib/logstash/codecs/sflow/packet_header.rb
+++ b/lib/logstash/codecs/sflow/packet_header.rb
@@ -39,7 +39,7 @@ class TcpHeader < BinData::Record
   array :tcp_options, :initial_length => lambda { (((tcp_header_length * 4) - 20)/4).ceil }, :onlyif => :is_options? do
     string :tcp_option, :length => 4, :pad_byte => "\0"
   end
-  bit :data, :nbits => lambda { size_header - (tcp_header_length * 4 * 8) }
+  bit :data, :nbits => lambda { size_header - data.rel_offset * 8 }
 
   def is_options?
     tcp_header_length.to_i > 5


### PR DESCRIPTION
This pull request fixes a couple of parsing errors that we've seen in real deployments, specifically:

* RawPacketHeader containing IPv4 with protocol=6 but not containing a TCP header
* TCP header inside RawPacketHeader having tcp_header_length>5 but not containing TCP options
* TCP header inside RawPacketHeader having bad tcp_header_length (set by a malicious party)

Those changes fix all of the errors that we've seen so far. A generic fix for this kind of issues is to parse as many header fields as fit inside `header_size` bytes, but sans a modification to BinData, that seems to require a lot of `onlyif` boilerplate.