### PR TITLE
fix lag counters and add wifi and ovs counters

### DIFF
--- a/lib/logstash/codecs/sflow/counter_record.rb
+++ b/lib/logstash/codecs/sflow/counter_record.rb
@@ -98,6 +98,31 @@ class Vlan < BinData::Record
 end
 
 # noinspection RubyResolve
+class Ieee80211Counters < BinData::Record
+  endian :big
+  uint32 :dot11_transmitted_fragments
+  uint32 :dot11_multicast_transmitted_frames
+  uint32 :dot11_failures
+  uint32 :dot11_retries
+  uint32 :dot11_multiple_retries
+  uint32 :dot11_duplicate_frames
+  uint32 :dot11_rts_successes
+  uint32 :dot11_rts_failures
+  uint32 :dot11_ack_failures
+  uint32 :dot11_received_fragments
+  uint32 :dot11_multicast_received_frames
+  uint32 :dot11_fcs_errors
+  uint32 :dot11_transmitted_frames
+  uint32 :dot11_wep_undecryptables
+  uint32 :dot11_qos_discarded_fragments
+  uint32 :dot11_associated_stations
+  uint32 :dot11_qos_cf_polls_eceived
+  uint32 :dot11_qos_cf_polls_unused
+  uint32 :dot11_qos_cf_polls_unusable
+  uint32 :dot11_qos_cf_polls_lost
+end
+
+# noinspection RubyResolve
 class ProcessorInformation < BinData::Record
   endian :big
   uint32 :five_sec_cpu_percent
@@ -105,6 +130,14 @@ class ProcessorInformation < BinData::Record
   uint32 :five_min_cpu_percent
   uint64 :total_memory
   uint64 :free_memory
+end
+
+# noinspection RubyResolve
+class RadioUtilization < BinData::Record
+  endian :big
+  uint32 :radio_elapsed_time_ms
+  uint32 :radio_on_channel_time_ms
+  uint32 :radio_on_channel_busy_time_ms
 end
 
 # noinspection RubyResolve
@@ -396,4 +429,15 @@ class VirtNetIo < BinData::Record
   uint32 :tx_packets
   uint32 :tx_errs
   uint32 :tx_drop
+end
+
+# noinspection RubyResolve
+class OvsDpStats < BinData::Record
+  endian :big
+  uint32 :ovs_dp_hits                                                
+  uint32 :ovs_dp_misses
+  uint32 :ovs_dp_lost
+  uint32 :ovs_dp_mask_hits
+  uint32 :ovs_dp_flows
+  uint32 :ovs_dp_masks
 end

--- a/lib/logstash/codecs/sflow/sample.rb
+++ b/lib/logstash/codecs/sflow/sample.rb
@@ -46,7 +46,10 @@ class CounterSampleRecordData < BinData::Choice
   token_ring '0-3'
   hundred_base_vg '0-4'
   vlan '0-5'
+  ieee80211_counters '0-6'
+  lag_port_stats '0-7'
   processor_information '0-1001'
+  radio_utilization '0-1002'
   of_port '0-1004'
   port_name '0-1005'
   host_descr '0-2000'
@@ -66,6 +69,7 @@ class CounterSampleRecordData < BinData::Choice
   virt_disk_io '0-2103'
   virt_net_io '0-2104'
   http_counters '0-2201'
+  ovs_dp_stats '0-2207'
   skip :default, :length => :record_length
 end
 


### PR DESCRIPTION
The lag counters weren't working as the needed entry was missing in the `CounterSampleRecordData` choice class. This entry has been added and tested by a user [here](https://github.com/robcowart/elastiflow/issues/500#issuecomment-590969993).

Support is also added for wifi and openvswitch datapath counters.